### PR TITLE
Fix range library function with null item

### DIFF
--- a/src/LanguageUtil.php
+++ b/src/LanguageUtil.php
@@ -114,6 +114,10 @@ final class LanguageUtil
                 bool $inclusiveLower = true,
                 bool $inclusiveUpper = true
             ) : bool {
+                if ($item === null) {
+                    return false;
+                }
+
                 if ($item > $upper || (!$inclusiveLower && $item >= $upper)) {
                     return false;
                 } elseif ($item < $lower || (!$inclusiveUpper && $item <= $lower)) {

--- a/tests/src/LanguageUtilTest.php
+++ b/tests/src/LanguageUtilTest.php
@@ -156,4 +156,27 @@ class LanguageUtilTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($r, 'Expect false, since 1 < 3 < 3');
     }
+
+    /**
+     * @covers ::getMethod
+     */
+    public function testRangeNull()
+    {
+        $p = new ExpressionParser(
+            (new Language())
+                ->set(
+                    'range',
+                    LanguageUtil::getMethod('range')
+                )
+        );
+
+        $r = $p->evaluate([
+            'range',
+            null,
+            0,
+            4
+        ]);
+
+        $this->assertFalse($r);
+    }
 }


### PR DESCRIPTION
Range input item `null` should return always `false`